### PR TITLE
[debian] Add --no-parallel to overide dh_auto_clean and dh_auto_test

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,14 @@ LIBDIR=usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 override_dh_auto_build:
 	dh_auto_build -- LIBDIR=$(LIBDIR) release pkgconfig debian/libglibutil.install debian/libglibutil-dev.install
 
+override_dh_auto_clean:
+	dh_auto_clean --no-parallel
+
 override_dh_auto_install:
 	dh_auto_install -- LIBDIR=$(LIBDIR) install-dev
+
+override_dh_auto_test:
+	dh_auto_test --no-parallel
 
 %:
 	dh $@


### PR DESCRIPTION
This is needed to build libglibutil on Debian and Ubuntu which is using GNU Make
version 4.3 like Debian 11 Bullseye, Debian 12 Bookworm, Ubuntu 21.10 Impish,
Ubuntu 22.04 LTS Jammy and maybe on future release too or it will stop building
with errors like this

```
 dpkg-buildpackage -us -uc -ui -b
dpkg-buildpackage: info: source package libglibutil
dpkg-buildpackage: info: source version 1.0.63
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Slava Monich <slava.monich@jolla.com>
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 debian/rules clean
dh clean
   dh_auto_clean
        make -j2 clean
make[1]: Entering directory '/tmp/libglibutil'
make -C test clean
make[2]: Entering directory '/tmp/libglibutil/test'
make[3]: Entering directory '/tmp/libglibutil/test/test_history'
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
../common/Makefile:110: *** multiple target patterns.  Stop.
make[3]: Leaving directory '/tmp/libglibutil/test/test_history'
make[2]: *** [Makefile:5: clean] Error 2
make[2]: Leaving directory '/tmp/libglibutil/test'
make[1]: *** [Makefile:155: clean] Error 2
make[1]: Leaving directory '/tmp/libglibutil'
dh_auto_clean: error: make -j2 clean returned exit code 2
make: *** [debian/rules:16: clean] Error 25
dpkg-buildpackage: error: debian/rules clean subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -b failed
```