### PR TITLE
Another way to fix parallel build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ print_coverage_lib:
 	@echo $(COVERAGE_STATIC_LIB)
 
 clean:
-	$(MAKE) -C test clean
+	make -C test clean
 	rm -fr test/coverage/results test/coverage/*.gcov
 	rm -f *~ $(SRC_DIR)/*~ $(INCLUDE_DIR)/*~
 	rm -fr $(BUILD_DIR) RPMS installroot
@@ -162,7 +162,7 @@ clean:
 	rm -fr debian/*.install
 
 test:
-	$(MAKE) -C test test
+	make -C test test
 
 $(BUILD_DIR):
 	mkdir -p $@

--- a/debian/rules
+++ b/debian/rules
@@ -9,14 +9,8 @@ LIBDIR=usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 override_dh_auto_build:
 	dh_auto_build -- LIBDIR=$(LIBDIR) release pkgconfig debian/libglibutil.install debian/libglibutil-dev.install
 
-override_dh_auto_clean:
-	dh_auto_clean --no-parallel
-
 override_dh_auto_install:
 	dh_auto_install -- LIBDIR=$(LIBDIR) install-dev
-
-override_dh_auto_test:
-	dh_auto_test --no-parallel
 
 %:
 	dh $@


### PR DESCRIPTION
`--no-parallel` option is not supported by old systems