### PR TITLE
[build] Define and use MAKE var instead of explicitly calling make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ SRC = \
 CC ?= $(CROSS_COMPILE)gcc
 STRIP ?= strip
 LD = $(CC)
+MAKE ?= make
 WARNINGS = -Wall
 INCLUDES = -I$(INCLUDE_DIR)
 BASE_FLAGS = -fPIC
@@ -161,7 +162,7 @@ print_coverage_lib:
 	@echo $(COVERAGE_STATIC_LIB)
 
 clean:
-	make -C test clean
+	$(MAKE) -C test clean
 	rm -fr test/coverage/results test/coverage/*.gcov
 	rm -f *~ $(SRC_DIR)/*~ $(INCLUDE_DIR)/*~
 	rm -fr $(BUILD_DIR) RPMS installroot
@@ -171,7 +172,7 @@ clean:
 	rm -fr debian/*.install
 
 test:
-	make -C test test
+	$(MAKE) -C test test
 
 $(BUILD_DIR):
 	mkdir -p $@


### PR DESCRIPTION
There are multiple `make` implementations and nothing guarantees that the `make` executable is `gmake`, which is what [this Makefile](https://github.com/sailfishos/libglibutil/blob/master/Makefile) requires.

As a practical example https://chimera-linux.org/ uses [`bmake`](https://pkgs.chimera-linux.org/packages?name=cmd%3Amake) as the default `make` while also having [`gmake`](https://pkgs.chimera-linux.org/packages?name=cmd%3Agmake) easily available for projects needing it.

My packaging of this project where this is used: https://github.com/JamiKettunen/cports/commit/db1b003f