### PR TITLE
[build] Drop explicit MAKE var definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ SRC = \
 CC ?= $(CROSS_COMPILE)gcc
 STRIP ?= strip
 LD = $(CC)
-MAKE ?= make
 WARNINGS = -Wall
 INCLUDES = -I$(INCLUDE_DIR)
 BASE_FLAGS = -fPIC


### PR DESCRIPTION
`MAKE=make` is part of [IEEE Std 1003.1-2017 section `Default Rules` subsection `MACROS`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html) and explicitly defining it is redundant.

Addresses https://github.com/sailfishos/libglibutil/pull/5#issuecomment-1711548115.