### PR TITLE
Compatibility with clang -fsanitize=cfi

### DIFF
--- a/src/gutil_timenotify.c
+++ b/src/gutil_timenotify.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2016-2019 Jolla Ltd.
  *
- * You may use this file under the terms of BSD license as follows:
+ * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,12 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/timerfd.h>
+
+#ifdef __clang__
+#define NO_SANITIZE_CFI __attribute__((no_sanitize("cfi")))
+#else
+#define NO_SANITIZE_CFI
+#endif
 
 #ifndef TFD_TIMER_CANCEL_ON_SET
 #  define TFD_TIMER_CANCEL_ON_SET (1 << 1)
@@ -186,6 +192,7 @@ gutil_time_notify_init(
     }
 }
 
+NO_SANITIZE_CFI
 static
 void
 gutil_time_notify_finalize(

--- a/test/common/test_object.c
+++ b/test/common/test_object.c
@@ -1,8 +1,8 @@
 /*
+ * Copyright (C) 2018-2023 Slava Monich <slava@monich.com>
  * Copyright (C) 2018 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
  *
- * You may use this file under the terms of BSD license as follows:
+ * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -49,6 +49,9 @@ test_object_init(
     g_atomic_int_inc(&test_object_count);
 }
 
+#ifdef __clang__
+__attribute__((no_sanitize("cfi")))
+#endif
 static
 void
 test_object_finalize(


### PR DESCRIPTION
This should fix issue #7.

Statements like
```c
    G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
```
seem to produce false alarms no matter what you do (which questions the usability of this CFI thing)