### PR TITLE
[build] Support pkg-config cross-compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ SRC = \
 # Tools and flags
 #
 
+PKG_CONFIG ?= pkg-config
 CC ?= $(CROSS_COMPILE)gcc
 STRIP ?= strip
 LD = $(CC)
@@ -86,10 +87,10 @@ BASE_FLAGS = -fPIC
 FULL_CFLAGS = $(BASE_FLAGS) $(CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) \
   -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 \
   -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_MAX_ALLOWED \
-  -MMD -MP $(shell pkg-config --cflags $(PKGS))
+  -MMD -MP $(shell $(PKG_CONFIG) --cflags $(PKGS))
 FULL_LDFLAGS = $(BASE_FLAGS) $(LDFLAGS) -shared -Wl,-soname,$(LIB_SONAME) \
   -Wl,--version-script=$(LIB_NAME).ver
-LIBS := $(shell pkg-config --libs $(PKGS))
+LIBS := $(shell $(PKG_CONFIG) --libs $(PKGS))
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =
 COVERAGE_FLAGS = -g

--- a/test/common/Makefile
+++ b/test/common/Makefile
@@ -41,6 +41,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 # Tools and flags
 #
 
+PKG_CONFIG ?= pkg-config
 CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS = -Wall
@@ -51,9 +52,9 @@ BASE_CFLAGS = $(BASE_FLAGS) $(CFLAGS)
 FULL_CFLAGS = $(BASE_CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
   -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 \
   -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_MAX_ALLOWED \
-  $(shell pkg-config --cflags $(PKGS))
+  $(shell $(PKG_CONFIG) --cflags $(PKGS))
 FULL_LDFLAGS = $(BASE_LDFLAGS)
-LIBS = $(shell pkg-config --libs $(PKGS))
+LIBS = $(shell $(PKG_CONFIG) --libs $(PKGS))
 QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =


### PR DESCRIPTION
Previously to cross-compile one would need to add a `pkg-config` executable in `$PATH` wrapping all the search paths required; now one can e.g. `make PKG_CONFIG=foreign-arch-target-pkg-config` with the wrapper executable being separate and allowing programs for host to also be built if needed for example.