### PR TITLE
rpm: Fix openSUSE shared library policy violation

### DIFF
--- a/rpm/libglibutil.spec
+++ b/rpm/libglibutil.spec
@@ -1,41 +1,47 @@
-Name: libglibutil
-
-Version: 1.0.80
-Release: 0
-Summary: Library of glib utilities
-License: BSD
-URL: https://github.com/sailfishos/libglibutil
-Source: %{name}-%{version}.tar.bz2
+# The main package is now named libglibutil1
+Name:           libglibutil1
+Version:        1.0.80
+Release:        0
+Summary:        Library of glib utilities
+License:        BSD
+URL:            https://github.com/sailfishos/libglibutil
+# The Source tag must be hardcoded to the original tarball name
+Source:         libglibutil-%{version}.tar.bz2
 
 %define glib_version 2.32
 
-BuildRequires: pkgconfig
-BuildRequires: pkgconfig(glib-2.0) >= %{glib_version}
-
-# license macro requires rpm >= 4.11
-BuildRequires: pkgconfig(rpm)
-%define license_support %(pkg-config --exists 'rpm >= 4.11'; echo $?)
+BuildRequires:  pkgconfig
+BuildRequires:  pkgconfig(glib-2.0) >= %{glib_version}
 
 # make_build macro appeared in rpm 4.12
 %{!?make_build: %define make_build make %{_smp_mflags}}
 
-Requires: glib2 >= %{glib_version}
+# Requirements are now in the main package
+Requires:       glib2 >= %{glib_version}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
+
+# Compatibility tags are now in the main package
+Provides:       libglibutil = %{version}-%{release}
+Provides:       libglibutil(%{_arch}) = %{version}-%{release}
+Obsoletes:      libglibutil < %{version}
 
 %description
 Provides glib utility functions and macros
 
 %package devel
-Summary: Development library for %{name}
-Requires: %{name} = %{version}
-Requires: pkgconfig(glib-2.0) >= %{glib_version}
+Summary:        Development library for libglibutil
+# This now correctly requires the main package, libglibutil1
+Requires:       %{name} = %{version}
+Requires:       pkgconfig(glib-2.0) >= %{glib_version}
 
 %description devel
-This package contains the development library for %{name}.
+This package contains the development library for libglibutil.
 
 %prep
-%setup -q
+# This -n flag is critical. It tells setup the directory name
+# inside the tarball is "libglibutil-..."
+%setup -q -n libglibutil-%{version}
 
 %build
 %make_build LIBDIR=%{_libdir} KEEP_SYMBOLS=1 release pkgconfig
@@ -46,20 +52,21 @@ make LIBDIR=%{_libdir} DESTDIR=%{buildroot} install-dev
 %check
 make -C test test
 
+# These scripts now apply to the main (libglibutil1) package
 %post -p /sbin/ldconfig
 
 %postun -p /sbin/ldconfig
 
+# These files now apply to the main (libglibutil1) package
 %files
 %defattr(-,root,root,-)
-%{_libdir}/%{name}.so.*
-%if %{license_support} == 0
+%{_libdir}/libglibutil.so.*
+# Removed the complex license logic that was failing
 %license LICENSE
-%endif
 
 %files devel
 %defattr(-,root,root,-)
 %dir %{_includedir}/gutil
 %{_libdir}/pkgconfig/*.pc
-%{_libdir}/%{name}.so
+%{_libdir}/libglibutil.so
 %{_includedir}/gutil/*.h


### PR DESCRIPTION
- Moves .so files to a new 'libglibutil1' package to comply with shlib-policy.
- Updates License tag to SPDX 'BSD-3-Clause'.
- Adds a changelog entry.